### PR TITLE
pouchdb-upsert: Add empty object as possible argument for UpsertDiffCallback

### DIFF
--- a/types/pouchdb-upsert/index.d.ts
+++ b/types/pouchdb-upsert/index.d.ts
@@ -55,7 +55,7 @@ declare namespace PouchDB {
                           callback: Core.Callback<UpsertResponse>): void;
   }
 
-  type UpsertDiffCallback<Content extends {}> = (doc: Core.Document<Content>) => Core.Document<Content> | boolean;
+  type UpsertDiffCallback<Content extends {}> = (doc: Core.Document<Content> | {}) => Core.Document<Content> | boolean;
 
   interface UpsertResponse {
     id: Core.DocumentId;


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/pouchdb/upsert : "If the document does not already exist, then {} will be the input to diffFunc"
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

